### PR TITLE
fix: Error: Can't resolve 'flowise-embed/dist/web'

### DIFF
--- a/src/BubbleChat.tsx
+++ b/src/BubbleChat.tsx
@@ -22,7 +22,7 @@ export const BubbleChat = (props: Props) => {
 
   useEffect(() => {
     ;(async () => {
-      await import('flowise-embed/dist/web')
+      await import('flowise-embed/dist/web.js')
       setIsInitialized(true)
     })()
     return () => {

--- a/src/FullPageChat.tsx
+++ b/src/FullPageChat.tsx
@@ -24,7 +24,7 @@ export const FullPageChat = ({ style, className, ...assignableProps }: Props) =>
 
   useEffect(() => {
     ;(async () => {
-      await import('flowise-embed/dist/web')
+      await import('flowise-embed/dist/web.js')
     })()
   }, [])
 


### PR DESCRIPTION
`Error: Can't resolve 'flowise-embed/dist/web'`
Webpack 5 can't resolve not fully specified files.

It could be temporarily fix by:

```js
chainWebpack: (config) => {
  // fix: Error: Can't resolve 'flowise-embed/dist/web'
  config.module?.rules?.push({
    test: /\.m?js$/,
    resolve: {
      fullySpecified: false,
    },
  });
},
```

To resolve this, fix `'flowise-embed/dist/web'` to `'flowise-embed/dist/web.js'`
@HenryHengZJ 