### PR TITLE
chore: bump flowise-embed-react to 3.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flowise-embed-react",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "React library to display flowise chatbot on your website",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2647,10 +2647,10 @@ flatted@^3.2.7:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
 
-flowise-embed@3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/flowise-embed/-/flowise-embed-3.1.3.tgz#fd3d50057df738aec2205b470d5cc39516e1b648"
-  integrity sha512-en421zUluAvDV6sEonYFhmqpf8ZIE2FjC/l4TT0xb8vNF0/fjF9S3glP6L2eePC7SPsskuk4po/7MmXFgVRHoA==
+flowise-embed@3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/flowise-embed/-/flowise-embed-3.1.4.tgz#7b9f7eb3f2f0a1cfa452cf6a90215f98fcafb1d2"
+  integrity sha512-qc+9xOPY744QnjHuTVlx07g1j4zm9O6lFElhBaj77yerKDdR3T3YRQLGzEHWOdpLgXUu3SUyVvEwG1+HnMMVrA==
   dependencies:
     "@babel/core" "^7.22.1"
     "@microsoft/fetch-event-source" "^2.0.1"


### PR DESCRIPTION
Automated version bump after publishing `flowise-embed-react@3.1.4` to npm with tag `dev`.